### PR TITLE
Use previous options

### DIFF
--- a/background/td.js
+++ b/background/td.js
@@ -83,7 +83,10 @@ function start_tamper_listener(){
 function user_confirm_tamper(){
 	return new Promise(done=>{
 		browser.windows.create({
-			url: "popups/confirm_tamper/popup.html",
+			url: "popups/confirm_tamper/popup.html?"+encodeURIComponent(JSON.stringify({
+				types: types,
+				pattern: pattern,
+			})),
 			type: "panel",
 			width: 1200,
 			height: 800,

--- a/popups/confirm_tamper/popup.js
+++ b/popups/confirm_tamper/popup.js
@@ -23,4 +23,21 @@ function firefox57_workaround_for_blank_panel() {
 	});
 }
 
+function load_last_options() {
+	const last_options = JSON.parse(decodeURIComponent(window.location.href.split("?")[1]));
+
+	last_options.types = last_options.types.reduce((acc, value) => {
+		acc[value] = true;
+		return acc;
+	}, {});
+	if (Object.keys(last_options.types).length === 0)
+		last_options.types = { main_frame: true, xmlhttprequest: true };
+	document.querySelectorAll(".types").forEach((elem) => {
+		elem.checked = last_options.types[elem.value];
+	});
+
+	document.querySelector("#matchregex").value = last_options.pattern || "(.*?)";
+}
+
 firefox57_workaround_for_blank_panel();
+load_last_options();


### PR DESCRIPTION
Remember previous tampering options. Options aren't remembered after restart. Options API should be used to do that.