### PR TITLE
Remember tab option

### DIFF
--- a/background/td.js
+++ b/background/td.js
@@ -91,6 +91,7 @@ function user_confirm_tamper(tab_id){
 			url: "popups/confirm_tamper/popup.html?"+encodeURIComponent(JSON.stringify({
 				types: types,
 				pattern: pattern,
+				tab: tabId !== browser.tabs.TAB_ID_NONE,
 			})),
 			type: "panel",
 			width: 1200,

--- a/popups/confirm_tamper/popup.js
+++ b/popups/confirm_tamper/popup.js
@@ -38,6 +38,7 @@ function load_last_options() {
 	});
 
 	document.querySelector("#matchregex").value = last_options.pattern || "(.*?)";
+	document.querySelector("#tab").checked = last_options.tab;
 }
 
 firefox57_workaround_for_blank_panel();


### PR DESCRIPTION
Since limiting tampering to the current tab and remembering previous options were two different PRs, tab option couldn't be remembered.